### PR TITLE
Fix Railway deployment: Add Node.js to build environment

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,11 @@
+[phases.setup]
+nixPkgs = ["python310", "nodejs-18_x", "npm-9_x"]
+
+[phases.install]
+cmds = ["pip install -r requirements.txt"]
+
+[phases.build]
+cmds = ["bash build.sh"]
+
+[start]
+cmd = "python api_server.py"

--- a/railway.json
+++ b/railway.json
@@ -4,7 +4,6 @@
     "builder": "NIXPACKS"
   },
   "deploy": {
-    "startCommand": "bash build.sh && python api_server.py",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
   }


### PR DESCRIPTION
Railway was failing to build the React frontend because npm wasn't available. Added nixpacks.toml to configure both Python and Node.js environments, allowing the build script to successfully compile the frontend before starting the API server.